### PR TITLE
Prepare code-signing documentation

### DIFF
--- a/CODE_SIGNING.md
+++ b/CODE_SIGNING.md
@@ -1,0 +1,80 @@
+# Code signing policy
+
+This document describes the code-signing policy for ReciPro release artifacts.
+
+## Current status
+
+ReciPro is preparing code signing for Windows installer releases.
+
+Unless a GitHub Release explicitly states that `ReciProSetup.msi` is digitally signed, users should not assume that the installer is signed.
+
+## Official downloads
+
+Official release artifacts are published only from the ReciPro GitHub Releases page:
+
+- https://github.com/seto77/ReciPro/releases/latest
+
+Users should avoid downloading ReciPro installers from unofficial mirrors or third-party redistribution sites.
+
+## Intended signing model
+
+The intended signing route for Windows installer packages is an open-source code-signing service such as SignPath Foundation / SignPath.io.
+
+If this is approved and enabled, release artifacts are expected to be signed using Windows Authenticode signing and then published from GitHub Releases. For SignPath Foundation signing, the signer shown by Windows may be `SignPath Foundation` rather than the personal name of the ReciPro maintainer.
+
+## Scope of signing
+
+The intended signing scope is:
+
+- `ReciProSetup.msi`
+- ReciPro executable files built from this repository
+- ReciPro libraries built from this repository
+
+Third-party binaries should not be re-signed as if they were maintained by ReciPro unless their provenance and redistribution terms explicitly permit that use. See `THIRD-PARTY-NOTICES.md` for bundled or referenced third-party components and data.
+
+## Lightweight repository protection policy
+
+ReciPro is primarily a personal research-software project. The repository policy is intentionally lightweight: routine development should remain possible without mandatory pull requests, external approvals, required signed commits, or required status checks.
+
+For release integrity, the intended minimum protection is limited to release-critical history:
+
+- the default branch, `master`, should not be force-pushed or deleted;
+- release tags matching `v*` should not be deleted or moved after creation;
+- release builds should be produced from the public GitHub repository and published as GitHub Releases.
+
+This keeps day-to-day development simple while preserving the correspondence between a released installer, the release tag, and the public source tree.
+
+## Maintainer role
+
+ReciPro is maintained by Seto Y. The maintainer is responsible for preparing releases, reviewing signing requests, and publishing release artifacts.
+
+## Verifying an installer
+
+### Hash check
+
+Users can compute the SHA256 hash of a downloaded installer in PowerShell:
+
+```powershell
+Get-FileHash .\ReciProSetup.msi -Algorithm SHA256
+```
+
+The hash can then be compared with the value published in the corresponding GitHub Release, if provided.
+
+### Digital-signature check after signing is enabled
+
+After code signing is enabled for a release, users can inspect the installer from Windows Explorer:
+
+1. Right-click `ReciProSetup.msi`.
+2. Open **Properties**.
+3. Open the **Digital Signatures** tab.
+4. Confirm that the signature is valid and that the signer matches the signer documented for that release.
+
+Advanced users can also verify the installer with the Windows SDK `signtool` utility:
+
+```powershell
+signtool verify /pa /all ReciProSetup.msi
+```
+
+## Reporting suspicious artifacts
+
+If you find a suspicious ReciPro installer or a download link that does not match the official GitHub Releases page, please report it through the GitHub issue tracker or contact the maintainer through the project website.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ You may also cite the software repository itself when appropriate:
 * Access https://github.com/seto77/ReciPro/releases/latest, download *ReciProSetup.msi*, and execute it.
 * *ReciPro* runs on Windows OS with ***.Net Desktop Runtime 10.0*** (NOT ***.Net Runtime 10.0***), which can be installed from [here](https://dotnet.microsoft.com/download/dotnet/10.0).
 * *ReciPro* is distributed under the **MIT license** (free for anyone to use, modify, and redistribute).
+* For code-signing status and installer verification, see [Code signing policy](CODE_SIGNING.md).
+* For bundled or referenced third-party components and data, see [Third-party notices](THIRD-PARTY-NOTICES.md).
 
 ### Note on Windows Security Warnings
 
@@ -209,5 +211,3 @@ https://scholar.google.jp/scholar?cites=12625594477623342627
 <img src="https://seto77.github.io/ReciPro/assets/cap-en-auto/FormSpotIDV2.png" height="320px" alt="Spot ID v2">
 <img src="https://seto77.github.io/ReciPro/assets/cap-en-auto/FormMacro.png" height="320px" alt="Macro">
 <img src="https://seto77.github.io/ReciPro/assets/cap-en-auto/FormTrajectory.png" height="320px" alt="Electron Range Simulator">
-
-***

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,73 @@
+# Third-party notices
+
+This file summarizes third-party components, libraries, tools, and data sources that are bundled with or referenced by ReciPro. It is intended to support transparent redistribution and future code-signing review.
+
+This file is not a substitute for the original license texts. For each dependency, refer to the upstream project or data provider for the authoritative license terms.
+
+## Project license
+
+ReciPro itself is distributed under the MIT License. See `LICENSE.md`.
+
+## NuGet and library dependencies
+
+ReciPro uses third-party .NET libraries through project and package references. The exact dependency graph may vary by build configuration and target framework.
+
+Known or expected categories include:
+
+- .NET Desktop / Windows Forms runtime components from Microsoft
+- OpenGL-related libraries and controls
+- numerical and scientific-computing libraries
+- plotting, image, compression, and file-format support libraries where applicable
+
+Before submitting the project for code-signing review, the dependency list should be checked against the current `.csproj` files and NuGet lock information, and this notice file should be updated with exact package names, versions, upstream URLs, and licenses.
+
+## Built-in and downloaded crystallographic data
+
+### AMCSD
+
+ReciPro includes access to the American Mineralogist Crystal Structure Database (AMCSD). The README describes this as a built-in crystal database available immediately after installation.
+
+Reference:
+
+- Downs, R. T. & Hall-Wallace, M. (2003). The American Mineralogist Crystal Structure Database. *American Mineralogist*, **88**, 247-250.
+
+The redistribution terms and citation requirements for the exact AMCSD data bundled with ReciPro should be confirmed and documented here before final code-signing submission.
+
+### COD
+
+ReciPro can download and use data from the Crystallography Open Database (COD). The README describes COD data as downloaded automatically on first use and then available offline.
+
+The COD license and attribution requirements should be documented here with the exact terms used by the downloaded dataset.
+
+## External tools
+
+### ffmpeg
+
+ReciPro includes or uses ffmpeg-related functionality for generating rotation animation videos. ffmpeg has its own licensing terms, which depend on the build configuration and enabled codecs.
+
+Before final code-signing submission, confirm whether ffmpeg binaries are bundled in the installer or only expected to be available externally. If bundled, document:
+
+- the exact binary filename and version;
+- source or download URL;
+- license mode for that build;
+- whether any GPL components are enabled;
+- required license text and attribution.
+
+## Native and bundled binaries
+
+Any bundled native DLLs, EXEs, databases, fonts, icons, or other redistributable assets should be listed here before final code-signing submission.
+
+For each item, document:
+
+- file name or package name;
+- version, if applicable;
+- upstream project or provider;
+- license;
+- whether it is built from this repository or redistributed as an upstream binary;
+- whether it is intended to be signed by ReciPro.
+
+## Code-signing note
+
+The intended code-signing scope is limited to ReciPro release artifacts and binaries built from this repository. Third-party binaries should not be re-signed as if they were maintained by ReciPro unless their provenance and redistribution terms explicitly permit that use.
+
+See `CODE_SIGNING.md` for the release-artifact signing policy.


### PR DESCRIPTION
This PR prepares lightweight code-signing documentation for ReciPro while keeping the personal-development workflow simple.

Changes:

- Add `CODE_SIGNING.md` with current unsigned/preparation status, official download location, intended signing model, verification steps, and lightweight repository-protection policy.
- Add `THIRD-PARTY-NOTICES.md` as a starting point for documenting bundled/referenced third-party components and data before final SignPath/code-signing review.
- Link both documents from the README `Install` section.

Notes:

- This PR does not enable code signing yet.
- It intentionally does not require pull-request-only development, required approvals, signed commits, or required status checks.
- GitHub branch/tag Rulesets still need to be configured manually in repository settings because this GitHub connector exposes repository content/PR operations but not repository ruleset creation.